### PR TITLE
Properly destroy all excess children when shrinking the container items

### DIFF
--- a/Runtime/Scripts/Bindings/ContainerPropertyBinding.cs
+++ b/Runtime/Scripts/Bindings/ContainerPropertyBinding.cs
@@ -99,9 +99,9 @@ namespace de.JochenHeckl.Unity.DataBinding
                     UnityEngine.Object.Instantiate(elementTemplate, targetContainer);
                 }
 
-                while (elementCount < targetContainer.childCount)
+                for (var i = 0; i < targetContainer.childCount - elementCount; ++i)
                 {
-                    UnityEngine.Object.Destroy(targetContainer.GetChild(elementCount));
+                    UnityEngine.Object.Destroy(targetContainer.GetChild(elementCount + i).gameObject);
                 }
 
                 var childIndex = 0;


### PR DESCRIPTION
Object.Destroy() does not detach the children from their parent immediately, so the while-loop does not terminate when the items in the target container are being reduced.

Instead one could iterate over the number of excess children and trigger destruction while not relying on the childCount property.