### PR TITLE
Replace error-prone call to DestroyImmediate() with Destroy()

### DIFF
--- a/Runtime/Scripts/Bindings/ContainerPropertyBinding.cs
+++ b/Runtime/Scripts/Bindings/ContainerPropertyBinding.cs
@@ -110,9 +110,13 @@ namespace JH.DataBinding
 
         private void RemoveSuperfluousChildren(int numberOfChildrenToKeep)
         {
-            while (TargetContainer.childCount > numberOfChildrenToKeep)
+            for (
+              var childIndex = numberOfChildrenToKeep;
+              childIndex < TargetContainer.childCount;
+              ++childIndex
+            )
             {
-                UnityEngine.Object.DestroyImmediate(TargetContainer.GetChild(0).gameObject);
+                UnityEngine.Object.Destroy(TargetContainer.GetChild(childIndex).gameObject);
             }
         }
     }


### PR DESCRIPTION
The call to DestroyImmediate() may in some situations (e.g. physics callbacks) not be executed immediately. If that happens, RemoveSuperfluousChildren() in ContainerPropertyBinding gets stuck in an infinite loop.